### PR TITLE
修复Qmsg没有写api地址的问题...

### DIFF
--- a/lib/QQService.php
+++ b/lib/QQService.php
@@ -50,7 +50,7 @@ class QQService extends Service
                 ]
             ]);
 
-            $result = file_get_contents($qqApiUrl, false, $context);
+            $result = file_get_contents('https://qmsg.zendee.cn/send/'.$qqApiUrl, false, $context);
             self::logger(__CLASS__, $receiveQq, $params, $result);
         } catch (\Exception $exception) {
             self::logger(__CLASS__, '', '', '', $exception->getMessage());


### PR DESCRIPTION
经查，关于 #9 的问题是因为没有写Qmsg的接口地址导致请求没发出去...加上请求地址即可...