### PR TITLE
兼容1.2.0RC

### DIFF
--- a/lib/SmtpService.php
+++ b/lib/SmtpService.php
@@ -168,7 +168,7 @@ class SmtpService extends Service
     {
         $className = 'Widget_Abstract_' . $table;
         $db = Typecho_Db::get();
-        $widget = new $className(Typecho_Request::getInstance(), Typecho_Widget_Helper_Empty::getInstance());
+        $widget = $className::alloc();
         $db->fetchRow($widget->select()->where($key . ' = ?', $val)->limit(1), array($widget, 'push'));
 
         return $widget;


### PR DESCRIPTION
修复Smtp下1.2.0RC评论报错
`Argument 1 passed to Typecho\Widget::__construct() must be an instance of Typecho\Widget\Request, instance of Typecho\Request given, called in`